### PR TITLE
lab5 - tx monitoring show/config clis

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6423,5 +6423,42 @@ def del_subinterface(ctx, subinterface_name):
 
     config_db.set_entry('VLAN_SUB_INTERFACE', subinterface_name, None)
 
+#
+# Adds <key,value> to the tx monitoring config table
+#
+def tx_config(txKey, txVal):
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.mod_entry('TX_ERRORS_MONITORING', 'Config', {txKey: txVal})
+
+#
+# 'tx_monitoring' group ('config tx-monitoring ...'
+#
+@config.group(cls=clicommon.AbbreviationGroup)
+@click.pass_context
+def tx_monitoring(ctx):
+    """Config TX errors monitoring parameters"""
+    pass
+
+#
+# 'polling_period' command ('config tx-monitoring polling_period')
+#
+@tx_monitoring.command('polling_period')
+@click.argument('new_polling_period', type=click.IntRange(min=1), required=True)
+@click.pass_context
+def polling_period(ctx, new_polling_period):
+    """Config tx polling period"""
+    tx_config("Polling period", new_polling_period)
+
+#
+# 'threshold' command ('config tx-monitoring threshold')
+#
+@tx_monitoring.command('threshold')
+@click.argument('new_threshold', type=click.IntRange(min=1), required=True)
+@click.pass_context
+def threshold(ctx, new_threshold):
+    """Config tx errors threshold"""
+    tx_config('Threshold', new_threshold)
+
 if __name__ == '__main__':
     config()

--- a/show/main.py
+++ b/show/main.py
@@ -1839,6 +1839,46 @@ def peer(db, peer_ip):
 
     click.echo(tabulate(bfd_body, bfd_headers))
 
+#
+# 'tx_monitoring' group ("show tx-monitoring ...")
+#
+@cli.group(cls=clicommon.AliasedGroup)
+def tx_monitoring():
+    """Show details of the TX errors monitoring"""
+    pass
+
+#
+# 'config' subcommand ("show tx-monitoring config")
+#
+@tx_monitoring.command('config')
+def config():
+    """Show TX errors monitoring configuration"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    tx_monitoting_cfg = config_db.get_table('TX_ERRORS_MONITORING')
+    config_vals = tx_monitoting_cfg['Config']
+    click.echo('Polling period: %s' % config_vals['Polling period'])
+    click.echo('Threshold: %s' % config_vals['Threshold'])
+
+#
+# 'status' subcommand ("show tx-monitoring status")
+#
+@tx_monitoring.command('status')
+def status():
+    """Show ports's TX errors status"""
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)
+
+    tx_keys = state_db.keys(state_db.STATE_DB, "TX_ERRORS_STATUS_TABLE|*")
+    tx_headers = ['Interface', 'Status']
+    tx_body = []    
+
+    if tx_keys is not None:
+        for key in tx_keys:
+            iface_name= (key.split('|'))[1]
+            state = state_db.get(state_db.STATE_DB, key, 'Status')
+            tx_body.append([iface_name, state])
+    click.echo(tabulate(natsorted(tx_body), tx_headers))
 
 # Load plugins and register them
 helper = util_base.UtilHelper()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added show/conig CLIs for tx monitoring orch.
#### How I did it
Added support for the relevant CLIS in the show/config/main.py.
#### How to verify it
Manual testing.
#### Previous command output (if the output of a command-line utility has changed)
N/A
#### New command output (if the output of a command-line utility has changed)
For show CLI:
show tx-monitoring config will show the polling period and the threshold set for tx errors monitoring.
show tx-monitoring status will show the tx error status for all ports.
