### PR TITLE
Remove timer from FAST_REBOOT STATE_DB entry and use finalizer

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -148,7 +148,7 @@ function clear_boot()
 
     #clear_fast_boot
     if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
-        sonic-db-cli STATE_DB DEL "FAST_REBOOT|system" &>/dev/null || /bin/true
+        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "disable" &>/dev/null || /bin/true
     fi
 }
 
@@ -532,7 +532,7 @@ case "$REBOOT_TYPE" in
         check_warm_restart_in_progress
         BOOT_TYPE_ARG=$REBOOT_TYPE
         trap clear_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
-        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "1" "EX" "210" &>/dev/null
+        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "enable" &>/dev/null
         config warm_restart enable system
         ;;
     "warm-reboot")

--- a/sonic-utilities-data/templates/service_mgmt.sh.j2
+++ b/sonic-utilities-data/templates/service_mgmt.sh.j2
@@ -51,7 +51,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"


### PR DESCRIPTION
This should come along with sonic-buildimage PR implementing fast-reboot finalizing logic in finalize-warmboot script and other submodules PRs utilizing the change.

#### What I did
Remove the timer used to clear fast-reboot entry from state-db, instead it will be cleared by fast-reboot finalize function implemented inside finalize-warmboot script (which will be invoked since fast-reboot is using warm-reboot infrastructure).

As well instead of having "1" as the value for fast-reboot entry in state-db and deleting it when done it is now modified to set enable/disable according to the context.

As well all scripts reading this entry should be modified to the new value options.

#### How I did it
Removed the timer usage in the fast-reboot script and adding fast-reboot finalize logic to warm-reboot in the linked PR.
Use "enable/disable" instead of "1" as the entry value.

#### How to verify it
Run fast-reboot and check that the state-db entry for fast-reboot is being deleted after finalizing fast-reboot and not by an expiring timer.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

