### PR TITLE
fix fast-reboot db-migration

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -831,7 +831,7 @@ class DBMigrator():
         # reading FAST_REBOOT table can't be done with stateDB.get as it uses hget behind the scenes and the table structure is
         # not using hash and won't work.
         # FAST_REBOOT table exists only if fast-reboot was triggered.
-        keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT")
+        keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system")
         if keys:
             enable_state = 'true'
         else:

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -832,7 +832,7 @@ class DBMigrator():
         # not using hash and won't work.
         # FAST_REBOOT table exists only if fast-reboot was triggered.
         keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT")
-        if keys is not None:
+        if not keys:
             enable_state = 'true'
         else:
             enable_state = 'false'

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -832,7 +832,7 @@ class DBMigrator():
         # not using hash and won't work.
         # FAST_REBOOT table exists only if fast-reboot was triggered.
         keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT")
-        if not keys:
+        if keys:
             enable_state = 'true'
         else:
             enable_state = 'false'


### PR DESCRIPTION
This PR is for 202205 branch.

What I did
Fix DB migrator logic for migrating fast-reboot table, better handling of case fast-reboot is not set.

How I did it
Checking if fast-reboot table exists in DB.

How to verify it
Verified manually, migrating after fast-reboot and after cold/warm reboot.

Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)