### PR TITLE
set teamd timer to minimum for fast-reboot, preserve connected routes

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -525,6 +525,7 @@ case "$REBOOT_TYPE" in
         BOOT_TYPE_ARG=$REBOOT_TYPE
         trap clear_boot EXIT HUP INT QUIT TERM KILL ABRT ALRM
         sonic-db-cli STATE_DB HSET "FAST_RESTART_ENABLE_TABLE|system" "enable" "true" &>/dev/null
+        config warm_restart teamsyncd_timer 1
         config warm_restart enable system
         ;;
     "warm-reboot")
@@ -633,14 +634,9 @@ fi
 set +e
 
 if [[ "$REBOOT_TYPE" = "fast-reboot" ]]; then
-    # Clear all routes except of default routes for faster reconciliation time.
-    sonic-db-cli APPL_DB eval "
-        for _, k in ipairs(redis.call('keys', '*')) do
-            if string.match(k, 'ROUTE_TABLE:') and not string.match(k, 'ROUTE_TABLE:0.0.0.0/0') and not string.match(k, 'ROUTE_TABLE:::/0') then \
-                redis.call('del', k)
-            end
-        end
-    " 0 > /dev/null
+    # Clear all routes except of default and connected routes for faster reconciliation time.
+    debug "Clearing routes..."
+    python /usr/local/bin/fast-reboot-filter-routes.py
 fi
 
 # disable trap-handlers which were set before

--- a/scripts/fast-reboot-filter-routes.py
+++ b/scripts/fast-reboot-filter-routes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+import os
+import utilities_common.cli as clicommon
+import syslog
+import traceback
+import click
+from builtins import str #for unicode conversion in python2
+from swsscommon.swsscommon import ConfigDBConnector
+
+def get_connected_routes():
+    cmd = 'sudo vtysh -c "show ip route connected json"'
+    connected_routes = []
+    try:
+        output, ret = clicommon.run_command(cmd, return_cmd=True)
+        if ret != 0:
+            click.echo(output.rstrip('\n'))
+            sys.exit(ret)
+        if output is not None:
+            route_info = json.loads(output)
+            for route, info in route_info.items():
+                connected_routes.append(route)
+    except Exception:
+        ctx = click.get_current_context()
+        ctx.fail("Unable to get connected routes from bgp")
+    
+    return connected_routes
+
+def get_route(db, route):
+    key = 'ROUTE_TABLE:%s' % route
+    val = db.keys(db.APPL_DB, key)
+    try:
+        route = val[0].split(":", 1)[1]
+    except IndexError:
+        route = None
+    return route
+
+def generate_default_route_entries():
+    db = ConfigDBConnector()
+    db.db_connect(db.APPL_DB)
+
+    default_routes = []
+
+    ipv4_default = get_route(db, '0.0.0.0/0')
+    if ipv4_default is not None:
+        default_routes.append(ipv4_default)
+
+    ipv6_default = get_route(db, '::/0')
+    if ipv6_default is not None:
+        default_routes.append(ipv6_default)
+
+    return default_routes
+
+def filter_routes(preserved_routes):
+    db = ConfigDBConnector()
+    db.db_connect(db.APPL_DB)
+
+    key = 'ROUTE_TABLE:*'
+    routes = db.keys(db.APPL_DB, key)
+
+    for route in routes:
+        stripped_route = route.split(":", 1)[1]
+        if stripped_route not in preserved_routes:
+            db.delete(db.APPL_DB, route)
+
+def main():
+    default_routes = generate_default_route_entries()
+    connected_routes = get_connected_routes()
+    preserved_routes = set(default_routes + connected_routes)
+    filter_routes(preserved_routes)
+    return 0
+
+if __name__ == '__main__':
+    res = 0
+    try:
+        syslog.openlog('fast-reboot-filter-routes')
+        res = main()
+    except KeyboardInterrupt:
+        syslog.syslog(syslog.LOG_NOTICE, "SIGINT received. Quitting")
+        res = 1
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, "Got an exception %s: Traceback: %s" % (str(e), traceback.format_exc()))
+        res = 2
+    finally:
+        syslog.closelog()
+    try:
+        sys.exit(res)
+    except SystemExit:
+        os._exit(res)

--- a/scripts/fast-reboot-filter-routes.py
+++ b/scripts/fast-reboot-filter-routes.py
@@ -10,6 +10,8 @@ import click
 from builtins import str #for unicode conversion in python2
 from swsscommon.swsscommon import ConfigDBConnector
 
+ROUTE_OFFSET = 1
+
 def get_connected_routes():
     cmd = 'sudo vtysh -c "show ip route connected json"'
     connected_routes = []
@@ -31,11 +33,10 @@ def get_connected_routes():
 def get_route(db, route):
     key = 'ROUTE_TABLE:%s' % route
     val = db.keys(db.APPL_DB, key)
-    try:
-        route = val[0].split(":", 1)[1]
-    except IndexError:
-        route = None
-    return route
+    if val:
+        return val[0].split(":", 1)[ROUTE_OFFSET]
+    else:
+        return None
 
 def generate_default_route_entries():
     db = ConfigDBConnector()
@@ -61,7 +62,7 @@ def filter_routes(preserved_routes):
     routes = db.keys(db.APPL_DB, key)
 
     for route in routes:
-        stripped_route = route.split(":", 1)[1]
+        stripped_route = route.split(":", 1)[ROUTE_OFFSET]
         if stripped_route not in preserved_routes:
             db.delete(db.APPL_DB, route)
 

--- a/scripts/fast-reboot-filter-routes.py
+++ b/scripts/fast-reboot-filter-routes.py
@@ -10,7 +10,7 @@ import click
 from builtins import str #for unicode conversion in python2
 from swsscommon.swsscommon import ConfigDBConnector
 
-ROUTE_OFFSET = 1
+ROUTE_IDX = 1
 
 def get_connected_routes():
     cmd = 'sudo vtysh -c "show ip route connected json"'
@@ -34,7 +34,7 @@ def get_route(db, route):
     key = 'ROUTE_TABLE:%s' % route
     val = db.keys(db.APPL_DB, key)
     if val:
-        return val[0].split(":", 1)[ROUTE_OFFSET]
+        return val[0].split(":", 1)[ROUTE_IDX]
     else:
         return None
 
@@ -62,7 +62,7 @@ def filter_routes(preserved_routes):
     routes = db.keys(db.APPL_DB, key)
 
     for route in routes:
-        stripped_route = route.split(":", 1)[ROUTE_OFFSET]
+        stripped_route = route.split(":", 1)[ROUTE_IDX]
         if stripped_route not in preserved_routes:
             db.delete(db.APPL_DB, route)
 

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         'scripts/fanshow',
         'scripts/fast-reboot',
         'scripts/fast-reboot-dump.py',
+        'scripts/fast-reboot-filter-routes.py',
         'scripts/fdbclear',
         'scripts/fdbshow',
         'scripts/fibshow',


### PR DESCRIPTION
What I did
Set teamd-timer to minimal allowed value for fast-reboot (will be cleared when finalizing fast-reboot in warm-boot finalizer), preserving connected routes through fast-reboot to shorten dataplane downtime.

How I did it
Set teamd-timer to 1 sec (the minimal allowed value) when calling fast-reboot; added script to filter connected and default routes in fast-reboot.

How to verify it
Community fast-reboot test.

Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)