### PR TITLE
Add system display to platform summary

### DIFF
--- a/show/platform.py
+++ b/show/platform.py
@@ -17,7 +17,7 @@ def get_chassis_info():
     call fails we simply return N/A.
     """
 
-    keys = ["serial", "model", "revision"]
+    keys = ["serial", "model", "revision", "sys_display"]
 
     def try_get(platform, attr, fallback):
         try:
@@ -62,6 +62,7 @@ def summary(json):
         click.echo("ASIC: {}".format(platform_info['asic_type']))
         click.echo("ASIC Count: {}".format(platform_info['asic_count']))
         click.echo("Serial Number: {}".format(chassis_info['serial']))
+        click.echo("System Display Name: {}".format(chassis_info['sys_display']))
         click.echo("Model Number: {}".format(chassis_info['model']))
         click.echo("Hardware Revision: {}".format(chassis_info['revision']))
         switch_type = platform_info.get('switch_type')

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -28,9 +28,9 @@ class TestShowPlatform(object):
     TEST_ASIC_TYPE = "mellanox"
     TEST_ASIC_COUNT = 1
     TEST_SERIAL = "MT1822K07815"
+    TEST_SYS_DISPLAY = "N/A"
     TEST_MODEL = "MSN2700-CS2FO"
     TEST_REV = "A1"
-    TEST_SYS_DISPLAY = "N/A"
 
     # Test 'show platform summary'
     def test_summary(self):
@@ -40,9 +40,10 @@ class TestShowPlatform(object):
             ASIC: {}
             ASIC Count: {}
             Serial Number: {}
+            System Display Name: {}
             Model Number: {}
             Hardware Revision: {}
-            """.format(self.TEST_PLATFORM, self.TEST_HWSKU, self.TEST_ASIC_TYPE, self.TEST_ASIC_COUNT, self.TEST_SERIAL, self.TEST_MODEL, self.TEST_REV, self.TEST_SYS_DISPLAY)
+            """.format(self.TEST_PLATFORM, self.TEST_HWSKU, self.TEST_ASIC_TYPE, self.TEST_ASIC_COUNT, self.TEST_SERIAL, self.TEST_SYS_DISPLAY, self.TEST_MODEL, self.TEST_REV)
 
         with mock.patch("sonic_py_common.device_info.get_platform_info",
                 return_value={"platform": self.TEST_PLATFORM, "hwsku": self.TEST_HWSKU, "asic_type": self.TEST_ASIC_TYPE, "asic_count": self.TEST_ASIC_COUNT}):

--- a/tests/show_platform_test.py
+++ b/tests/show_platform_test.py
@@ -30,6 +30,7 @@ class TestShowPlatform(object):
     TEST_SERIAL = "MT1822K07815"
     TEST_MODEL = "MSN2700-CS2FO"
     TEST_REV = "A1"
+    TEST_SYS_DISPLAY = "N/A"
 
     # Test 'show platform summary'
     def test_summary(self):
@@ -41,12 +42,12 @@ class TestShowPlatform(object):
             Serial Number: {}
             Model Number: {}
             Hardware Revision: {}
-            """.format(self.TEST_PLATFORM, self.TEST_HWSKU, self.TEST_ASIC_TYPE, self.TEST_ASIC_COUNT, self.TEST_SERIAL, self.TEST_MODEL, self.TEST_REV)
+            """.format(self.TEST_PLATFORM, self.TEST_HWSKU, self.TEST_ASIC_TYPE, self.TEST_ASIC_COUNT, self.TEST_SERIAL, self.TEST_MODEL, self.TEST_REV, self.TEST_SYS_DISPLAY)
 
         with mock.patch("sonic_py_common.device_info.get_platform_info",
                 return_value={"platform": self.TEST_PLATFORM, "hwsku": self.TEST_HWSKU, "asic_type": self.TEST_ASIC_TYPE, "asic_count": self.TEST_ASIC_COUNT}):
             with mock.patch("show.platform.get_chassis_info",
-                            return_value={"serial": self.TEST_SERIAL, "model": self.TEST_MODEL, "revision": self.TEST_REV}):
+                            return_value={"serial": self.TEST_SERIAL, "model": self.TEST_MODEL, "revision": self.TEST_REV, "sys_display": self.TEST_SYS_DISPLAY}):
                 result = CliRunner().invoke(show.cli.commands["platform"].commands["summary"], [])
                 assert result.output == textwrap.dedent(expected_output)
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add 'System Display' field to 'show platform summary' cli to reflect the model name.
#### How I did it
Read 'sys_display' from chassis table in STATE_DB
#### How to verify it
Manual testing
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

